### PR TITLE
ProteusGridLayoutManager and ViewPager Example implemented

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         google()
         mavenCentral()
         jcenter()
+        maven { url "https://jitpack.io" }
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'

--- a/data/layout.json
+++ b/data/layout.json
@@ -130,6 +130,14 @@
           "padding": "16dp",
           "paddingBottom": "0dp"
         },
+
+        {
+          "type": "include",
+          "layout": "ViewPagerExample",
+          "padding": "16dp",
+          "paddingBottom": "0dp"
+        },
+
         {
           "type": "include",
           "layout": "SimpleDataBindingExample",

--- a/data/layouts.json
+++ b/data/layouts.json
@@ -253,7 +253,7 @@
           "items": "@{data.achievements}"
         },
         "layout_manager": {
-          "type": "LinearLayoutManager"
+          "type": "GridLayoutManager"
         },
         "adapter": {
           "@": {
@@ -270,13 +270,61 @@
               "gravity": "center",
               "text": "@{item}",
               "textSize": "14sp",
-              "textColor": "#323232"
+              "textColor": "#323232",
+              "onClick":"@{item}"
             }
           }
         }
       }
     ]
   },
+
+  "ViewPagerExample": {
+    "type": "FrameLayout",
+    "layout_width": "match_parent",
+    "layout_height": "wrap_content",
+    "padding": "16dp",
+    "paddingBottom": "0dp",
+    "children": [
+      {
+        "type": "RecyclerView",
+        "id" : "rc_view",
+        "layout_width": "match_parent",
+        "layout_height": "148dp",
+        "background": "#ffffff",
+        "data": {
+          "items": "@{data.achievements}"
+        },
+        "layout_manager": {
+          "type": "GridLayoutManager",
+          "orientation" : 1,
+          "numCols" : 2
+        },
+        "adapter": {
+          "@": {
+            "type": "SimpleListAdapter",
+            "item-count": "@{items.$length}",
+            "item-layout": {
+              "type": "TextView",
+              "data": {
+                "item": "@{items[$index]}"
+              },
+              "layout_width": "match_parent",
+              "layout_height": "match_parent",
+              "padding": "12dp",
+              "layout_marginBottom": "4dp",
+              "gravity": "center",
+              "text": "@{item}",
+              "textSize": "44sp",
+              "textColor": "#323232",
+              "onClick":"@{item}"
+            }
+          }
+        }
+      }
+    ]
+  },
+
   "AlertDialogLayout": {
     "type": "LinearLayout",
     "orientation": "vertical",

--- a/data/user.json
+++ b/data/user.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "name": "John Doe",
+    "name": "Ravi Ranjan",
     "location": {
       "country": "India",
       "city": "Bengaluru",

--- a/demo/src/main/java/com/flipkart/android/proteus/demo/ProteusActivity.java
+++ b/demo/src/main/java/com/flipkart/android/proteus/demo/ProteusActivity.java
@@ -255,7 +255,6 @@ public class ProteusActivity extends AppCompatActivity implements ProteusManager
     };
     
     View recyclerView = view.getViewManager().findViewById("rc_view");
-
     snapHelper.attachToRecyclerView((RecyclerView) recyclerView);
 
   }

--- a/demo/src/main/java/com/flipkart/android/proteus/demo/ProteusActivity.java
+++ b/demo/src/main/java/com/flipkart/android/proteus/demo/ProteusActivity.java
@@ -48,6 +48,9 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.LinearSnapHelper;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class ProteusActivity extends AppCompatActivity implements ProteusManager.Listener {
 
@@ -216,6 +219,45 @@ public class ProteusActivity extends AppCompatActivity implements ProteusManager
 
     // Add the inflated view to the container
     container.addView(view.getAsView());
+
+
+
+    LinearSnapHelper snapHelper = new LinearSnapHelper() {
+      @Override
+      public int findTargetSnapPosition(RecyclerView.LayoutManager layoutManager, int velocityX, int velocityY) {
+        View centerView = findSnapView(layoutManager);
+        if (centerView == null)
+          return RecyclerView.NO_POSITION;
+
+        int position = layoutManager.getPosition(centerView);
+        int targetPosition = -1;
+        if (layoutManager.canScrollHorizontally()) {
+          if (velocityX < 0) {
+            targetPosition = position - 1;
+          } else {
+            targetPosition = position + 1;
+          }
+        }
+
+        if (layoutManager.canScrollVertically()) {
+          if (velocityY < 0) {
+            targetPosition = position - 1;
+          } else {
+            targetPosition = position + 1;
+          }
+        }
+
+        final int firstItem = 0;
+        final int lastItem = layoutManager.getItemCount() - 1;
+        targetPosition = Math.min(lastItem, Math.max(targetPosition, firstItem));
+        return targetPosition;
+      }
+    };
+    
+    View recyclerView = view.getViewManager().findViewById("rc_view");
+
+    snapHelper.attachToRecyclerView((RecyclerView) recyclerView);
+
   }
 
   void reload() {

--- a/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/RecyclerViewModule.java
+++ b/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/RecyclerViewModule.java
@@ -22,6 +22,7 @@ import com.flipkart.android.proteus.support.v7.adapter.RecyclerViewAdapterFactor
 import com.flipkart.android.proteus.support.v7.adapter.SimpleListAdapter;
 import com.flipkart.android.proteus.support.v7.layoutmanager.LayoutManagerBuilder;
 import com.flipkart.android.proteus.support.v7.layoutmanager.LayoutManagerFactory;
+import com.flipkart.android.proteus.support.v7.layoutmanager.ProteusGridLayoutManager;
 import com.flipkart.android.proteus.support.v7.layoutmanager.ProteusLinearLayoutManager;
 import com.flipkart.android.proteus.support.v7.widget.RecyclerViewParser;
 
@@ -42,6 +43,8 @@ public class RecyclerViewModule implements ProteusBuilder.Module {
   static final String ADAPTER_SIMPLE_LIST = "SimpleListAdapter";
 
   static final String LAYOUT_MANAGER_LINEAR = "LinearLayoutManager";
+  static final String LAYOUT_MANAGER_GRID = "GridLayoutManager";
+
 
   @NonNull
   private final RecyclerViewAdapterFactory adapterFactory;
@@ -175,7 +178,7 @@ public class RecyclerViewModule implements ProteusBuilder.Module {
       }
 
       if (includeDefaultLayoutManagers) {
-        registerDefaultLayoutManagers();
+        registerGridLayoutManagers();
       }
 
       return new RecyclerViewModule(adapterFactory, layoutManagerFactory);
@@ -187,6 +190,10 @@ public class RecyclerViewModule implements ProteusBuilder.Module {
 
     private void registerDefaultLayoutManagers() {
       register(LAYOUT_MANAGER_LINEAR, ProteusLinearLayoutManager.BUILDER);
+    }
+
+    private void registerGridLayoutManagers() {
+      register(LAYOUT_MANAGER_GRID, ProteusGridLayoutManager.BUILDER);
     }
   }
 }

--- a/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
+++ b/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
@@ -1,0 +1,44 @@
+package com.flipkart.android.proteus.support.v7.layoutmanager;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
+
+import com.flipkart.android.proteus.support.v7.widget.ProteusRecyclerView;
+import com.flipkart.android.proteus.value.ObjectValue;
+
+public class ProteusGridLayoutManager extends GridLayoutManager {
+
+
+    private static final String ATTRIBUTE_COL = "numCols";
+    private static final String ATTRIBUTE_ORIENTATION = "orientation";
+    private static final String ATTRIBUTE_REVERSE_LAYOUT = "reverse";
+
+
+    public static final LayoutManagerBuilder<ProteusGridLayoutManager> BUILDER = new LayoutManagerBuilder<ProteusGridLayoutManager>() {
+
+        @NonNull
+        @Override
+        public ProteusGridLayoutManager create(@NonNull ProteusRecyclerView view, @NonNull ObjectValue config) {
+
+             int orientation = config.getAsInteger(ATTRIBUTE_ORIENTATION, GridLayoutManager.VERTICAL);
+             boolean reverseLayout = config.getAsBoolean(ATTRIBUTE_REVERSE_LAYOUT, false);
+
+             //todo get column from config attribute
+           // int col = config.getAsInteger(ATTRIBUTE_COL);
+
+            return new ProteusGridLayoutManager(view.getContext(), 2, orientation, reverseLayout);
+        }
+    };
+    
+    
+    public ProteusGridLayoutManager(Context context, int spanCount, int orientation, boolean reverseLayout) {
+        super(context, spanCount, orientation, reverseLayout);
+    }
+
+
+
+
+
+}

--- a/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
+++ b/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
@@ -1,6 +1,7 @@
 package com.flipkart.android.proteus.support.v7.layoutmanager;
 
 import android.content.Context;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -25,9 +26,9 @@ public class ProteusGridLayoutManager extends GridLayoutManager {
              int orientation = config.getAsInteger(ATTRIBUTE_ORIENTATION, GridLayoutManager.VERTICAL);
              boolean reverseLayout = config.getAsBoolean(ATTRIBUTE_REVERSE_LAYOUT, false);
 
-             //todo get column from config attribute
             int col = config.getAsInteger(ATTRIBUTE_COL, 1);
-            
+
+
 
             return new ProteusGridLayoutManager(view.getContext(), col, orientation, reverseLayout);
         }

--- a/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
+++ b/recyclerview-v7/src/main/java/com/flipkart/android/proteus/support/v7/layoutmanager/ProteusGridLayoutManager.java
@@ -26,9 +26,10 @@ public class ProteusGridLayoutManager extends GridLayoutManager {
              boolean reverseLayout = config.getAsBoolean(ATTRIBUTE_REVERSE_LAYOUT, false);
 
              //todo get column from config attribute
-           // int col = config.getAsInteger(ATTRIBUTE_COL);
+            int col = config.getAsInteger(ATTRIBUTE_COL, 1);
+            
 
-            return new ProteusGridLayoutManager(view.getContext(), 2, orientation, reverseLayout);
+            return new ProteusGridLayoutManager(view.getContext(), col, orientation, reverseLayout);
         }
     };
     


### PR DESCRIPTION
1. ### **ProteusGridLayoutManager** 

```
With respect to linear layout i have added GridLayout view because it is more generic and easy to use. it provides both the orientation of linear layout when span count of grid is set to 1 and changing the orientation of grid layout i.e 

span count = 1 & grid layout orientation  = Vertical,  will work just like vertical linear layout 
span count = 1 & grid layout orientation  = Horizontal , will work just like horizontal linear layout 

One can also reverse the layout with the help of boolean "reverseLayout".

In short gridLayout provides the same functionality of linear layout along with extra features of grid layout. 

the attribute for the orientation is received as "int" data type from the json and not as "string", and default value is set to 1 i.e  "GridLayoutManager.VERTICAL". By setting it to 0, it corresponds to "GridLayoutManager.HORIZONTAL". 
```

2. ### **ViewPager example**

```
the library supports the viewpager but there was no working example/demo in the code. just the logic part was implemented. i have extended it from logic part to demo part in "layouts.json" file with the attribute "ViewPagerExample". 

I am using the recycler view with the help of linear snap helper to mimic the behaviour of viewpager. 
```


